### PR TITLE
Some gnome 3.36 fixes: GObject.registerClass and so on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 #Translations
 *.mo
 .*~
+.idea

--- a/extension.js
+++ b/extension.js
@@ -30,7 +30,7 @@ const SETTINGS_ICON = 'emblem-system-symbolic';
 
 function launch_extension_prefs(uuid) {
     let appSys = Shell.AppSystem.get_default();
-    let app = appSys.lookup_app('gnome-shell-extension-prefs.desktop');
+    let app = appSys.lookup_app('org.gnome.Shell.Extensions.desktop');
     let info = app.get_app_info();
     let timestamp = global.display.get_current_time_roundtrip();
     info.launch_uris(
@@ -75,7 +75,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
 
         let available_width = monitor.width;
         let available_height = monitor.height;
-        if(is_primary) available_height -= Main.panel.actor.height;
+        if(is_primary) available_height -= Main.panel.height;
 
         let width = Math.round(available_width / 100 * 85);
 
@@ -213,7 +213,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
                     let items = this.suggestions_box._getMenuItems();
 
                     if(items.length > 1) {
-                        items[0].actor.remove_style_pseudo_class('active');
+                        items[0].remove_style_pseudo_class('active');
                         items[1].setActive(true);
                     }
                 }
@@ -254,7 +254,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
         }
         // Ctrl+V
         else if(control_mask && symbol == 118) {
-            this._clipboard.get_text(Lang.bind(this, function(clipboard, text) {
+            this._clipboard.get_text(St.ClipboardType.PRIMARY, Lang.bind(this, function(clipboard, text) {
                 if (Utils.is_blank(text)) {
                     return false;
                 }
@@ -271,7 +271,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
         else if(control_mask && symbol == 99) {
             let clutter_text = this.search_entry.get_clutter_text();
             let selection = clutter_text.get_selection();
-            this._clipboard.set_text(selection);
+            this._clipboard.set_text(St.ClipboardType.PRIMARY, selection);
         }
         // Ctrl+Shift+V - paste and search
         else if(control_mask && shift_mask && symbol == 86) {
@@ -279,7 +279,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
                 this._set_engine();
             }
 
-            this._clipboard.get_text(Lang.bind(this, function(clipboard, text) {
+            this._clipboard.get_text(St.ClipboardType.PRIMARY, Lang.bind(this, function(clipboard, text) {
                 if(Utils.is_blank(text)) {
                     this._show_hint({
                         text: 'Clipboard is empty.',
@@ -301,7 +301,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
                 this._set_engine();
             }
 
-            this._clipboard.get_text(Lang.bind(this, function(clipboard, url) {
+            this._clipboard.get_text(St.ClipboardType.PRIMARY, Lang.bind(this, function(clipboard, url) {
                 if(Utils.is_blank(url)) {
                     this._show_hint({
                         text: 'Clipboard is empty.',
@@ -703,6 +703,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
         let here = this;
 
         let request = Soup.Message.new('GET', url);
+        request.request_headers.append("Accept", "application/json;charset=utf-8");
 
         _httpSession.queue_message(request, function(_httpSession, message) {
             if(message.status_code === 200) {
@@ -867,7 +868,7 @@ const WebSearchDialog = GObject.registerClass (class WebSearchDialog extends Mod
             text.length,
             item._text.length
         );
-        item.actor.add_style_pseudo_class('active');
+        item.add_style_pseudo_class('active');
 
         this._display_helper(text);
 

--- a/helper.js
+++ b/helper.js
@@ -5,6 +5,7 @@ const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 const Soup = imports.gi.Soup;
 const Gio = imports.gi.Gio;
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 
 const Me = imports.misc.extensionUtils.getCurrentExtension();
@@ -16,9 +17,9 @@ const DUCKDUCKGO_API_URL =
     "https://api.duckduckgo.com/?format=json&no_redirect=1"+
     "&skip_disambig=1&q=";
 
-var HelperSpinnerMenuItem = class HelperSpinnerMenuItem extends PopupMenu.PopupBaseMenuItem {
-    constructor(text) {
-        super({
+var HelperSpinnerMenuItem = GObject.registerClass(class HelperSpinnerMenuItem extends PopupMenu.PopupBaseMenuItem {
+    _init(text) {
+        super._init({
             reactive: false,
             activate: false,
             hover: false,
@@ -35,13 +36,13 @@ var HelperSpinnerMenuItem = class HelperSpinnerMenuItem extends PopupMenu.PopupB
         });
         box.add(label);
 
-        this.actor.add_child(box);
+        this.add_child(box);
     }
-}
+});
 
-var DuckDuckGoHelperMenuItem = class DuckDuckGoHelperMenuItem extends PopupMenu.PopupBaseMenuItem {
-    constructor(data) {
-        super({
+var DuckDuckGoHelperMenuItem = GObject.registerClass(class DuckDuckGoHelperMenuItem extends PopupMenu.PopupBaseMenuItem {
+      _init(data) {
+        super._init({
             reactive: false,
             activate: false,
             hover: false,
@@ -85,9 +86,7 @@ var DuckDuckGoHelperMenuItem = class DuckDuckGoHelperMenuItem extends PopupMenu.
         let label = this._get_label(text, 'helper-abstract', max_length);
 
         grid_layout.attach(label, 1, 0, 1, 1);
-        this.actor.add_child(grid);
-
-        return true;
+        this.add_child(grid);
     }
 
     _get_icon(icon_info) {
@@ -108,7 +107,8 @@ var DuckDuckGoHelperMenuItem = class DuckDuckGoHelperMenuItem extends PopupMenu.
             image_file,
             info.width,
             info.height,
-            scale_factor
+            scale_factor,
+            1.0 // TODO: resource scale - is it correct?
         );
 
         this.icon_box = new St.BoxLayout({
@@ -148,7 +148,7 @@ var DuckDuckGoHelperMenuItem = class DuckDuckGoHelperMenuItem extends PopupMenu.
 
         return label;
     }
-};
+});
 
 var DuckDuckGoHelper = class DuckDuckGoHelper {
     constructor() {

--- a/suggestions_box.js
+++ b/suggestions_box.js
@@ -1,6 +1,7 @@
 const St = imports.gi.St;
 const Lang = imports.lang;
 const Main = imports.ui.main;
+const GObject = imports.gi.GObject;
 const Clutter = imports.gi.Clutter;
 const PopupMenu = imports.ui.popupMenu;
 const Params = imports.misc.params;
@@ -11,9 +12,9 @@ const Utils = Me.imports.utils;
 
 const ICONS = Utils.ICONS;
 
-const SuggestionMenuItem = class SuggestionMenuItem extends PopupMenu.PopupBaseMenuItem {
-    constructor(text, type, relevance, term, item_id, params) {
-        super(params);
+const SuggestionMenuItem = GObject.registerClass(class SuggestionMenuItem extends PopupMenu.PopupBaseMenuItem {
+    _init(text, type, relevance, term, item_id, params) {
+        super._init(params);
 
         this._text = text.trim();
         this._type = type;
@@ -63,8 +64,8 @@ const SuggestionMenuItem = class SuggestionMenuItem extends PopupMenu.PopupBaseM
         this._box.add(icon);
         this._box.add(label);
 
-        this.actor.add_child(this._box);
-        this.actor.label_actor = label;
+        this.add_child(this._box);
+        this.label_actor = label;
     }
 
     _onKeyPressEvent(actor, event) {
@@ -78,7 +79,7 @@ const SuggestionMenuItem = class SuggestionMenuItem extends PopupMenu.PopupBaseM
             return false;
         }
     }
-};
+});
 
 var SuggestionsBox = class SuggestionsBox extends PopupMenu.PopupMenu {
     constructor(search_dialog) {
@@ -188,7 +189,7 @@ var SuggestionsBox = class SuggestionsBox extends PopupMenu.PopupMenu {
 
         for(let i = 0; i < items.length; i++) {
             if(items[i]._item_id === item_id) {
-                items[i].activate();
+                items[i].activate(Clutter.get_current_event());
                 break;
             }
         }
@@ -219,7 +220,7 @@ var SuggestionsBox = class SuggestionsBox extends PopupMenu.PopupMenu {
             Lang.bind(this, this._on_activated)
         );
         item.connect(
-            'active-changed',
+            'notify::active',
             Lang.bind(this, this._on_active_changed)
         );
         this.addMenuItem(item)


### PR DESCRIPTION
Hi,

I've done some fixes that makes suggestion box work. There are sill some not fixed problems but looks like core feature works. Bugs that I've found:
- Suggestion popup has light color instead of dark that is visible on extension home page
- I see a lot of `Source ID XXXX was not found when attempting to remove it` in syslog
- I see `JS ERROR: TypeError: malformed UTF-8 character sequence at offset 90#012_get_suggestions/<@/home/XXXX/.local/share/gnome-shell/extensions/web_search_dialog@awamper.gmail.com/extension.js:710:30` -  I've tried with adding `request.request_headers.append("Accept", "application/json;charset=utf-8")` in `extension.js:706` but it doesn't help

Thank you for your work toward migration this plugin to 3.36.

Cheers,
Arek